### PR TITLE
Add database migration on startup to ensure schema exists before seeding

### DIFF
--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -28,7 +28,10 @@ if (!app.Environment.IsDevelopment())
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ChirpDBContext>();
-    
+
+    // Ensure database is created and migrated
+    db.Database.Migrate();
+
     // seeding db
     DbInitializer.SeedDatabase(db);
 }


### PR DESCRIPTION
I added db.Database.Migrate() to ensure that the db schema is created before seeding the data. This should fix the Azure deployment crash :)