### PR TITLE
optimized startup and request handling to reduce azure cpu  usage

### DIFF
--- a/src/Chirp.Infrastructure/DbInitializer.cs
+++ b/src/Chirp.Infrastructure/DbInitializer.cs
@@ -11,7 +11,19 @@ public static class DbInitializer
 {
     public static void SeedDatabase(ChirpDbContext chirpContext, UserManager<ApplicationUser> userManager)
     {
-        if (!(chirpContext.Authors.Any() && chirpContext.Cheeps.Any()))
+        // always seed identity users (since they have their own existence checks)
+        SeedIdentityUsers(userManager).GetAwaiter().GetResult();
+
+        // quick exit if it is already seeded
+        if (chirpContext.Cheeps.Any())
+        {
+            return;
+        }
+
+        // we disable change tracking so we can do faster bulk insert
+        chirpContext.ChangeTracker.AutoDetectChangesEnabled = false;
+
+        try
         {
             var a1 = new Author() { AuthorId = 1, Name = "Roger Histand", Email = "Roger+Histand@hotmail.com", Cheeps = new List<Cheep>() };
             var a2 = new Author() { AuthorId = 2, Name = "Luanna Muro", Email = "Luanna-Muro@ku.dk", Cheeps = new List<Cheep>() };
@@ -704,9 +716,11 @@ public static class DbInitializer
             chirpContext.Cheeps.AddRange(cheeps);
             chirpContext.SaveChanges();
         }
-
-        // seeding identity test users
-        SeedIdentityUsers(userManager).Wait();
+        finally
+        {
+            // aaaand then we re enable change tracking for the "normal" operations
+            chirpContext.ChangeTracker.AutoDetectChangesEnabled = true;
+        }
     }
 
     private static async Task SeedIdentityUsers(UserManager<ApplicationUser> userManager)

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -60,10 +60,12 @@ using (var scope = app.Services.CreateScope())
     {
         db.Database.Migrate();
     }
-    catch (SqliteException ex) when (ex.SqliteErrorCode == 1 && ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+    catch (SqliteException ex)
     {
-        // On existing SQLite files without migration history, migrations can fail the first time; in that case continue with the existing schema.
-        Console.WriteLine("SQLite schema already exists; skipping migrations.");
+        // we log the error
+        Console.WriteLine($"SQLite migration warning: {ex.Message}");
+
+        // only create create if db dont exist at all
         db.Database.EnsureCreated();
     }
 
@@ -81,23 +83,6 @@ app.UseStaticFiles();
 
 app.UseRouting();
 app.UseAuthentication();
-app.Use(async (context, next) =>
-{
-    if (context.User?.Identity?.IsAuthenticated == true)
-    {
-        var authorRepository = context.RequestServices.GetRequiredService<IAuthorRepository>();
-        var userManager = context.RequestServices.GetRequiredService<UserManager<ApplicationUser>>();
-        var user = await userManager.GetUserAsync(context.User);
-        if (user != null)
-        {
-            var authorName = user.UserName ?? user.Email ?? "unknown-user";
-            var authorEmail = user.Email ?? $"{authorName}@chirp.dk";
-            await authorRepository.MakeSureAuthorExists(authorName, authorEmail);
-        }
-    }
-
-    await next();
-});
 app.UseAuthorization();
 
 app.MapRazorPages();


### PR DESCRIPTION
added early exit in DbInitializer so we skip object creattion when its alrdy seeded. Also disabled EF Core change tracking while doing bulk seed so that we get faster inserts, and then enabling it again after. Removed some redundant per request middle ware too, whcih queried the db. And then also fixed a catch block that deleted db when migration errors occured.