### PR TITLE
fixed cheep posting from user timeline page :D

### DIFF
--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -12,7 +12,7 @@
     {
         <div class="cheepbox">
             <h3>What's on your mind @(User.Identity.Name)?</h3>
-            <form method="post" style="display:flex; gap:8px; align-items:flex-start;">
+            <form method="post" asp-page="Public" style="display:flex; gap:8px; align-items:flex-start;">
                 <input type="text" asp-for="Text" />
                 <input type="submit" value="Share" />
             </form>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -13,6 +13,7 @@
         <div class="cheepbox">
             <h3>What's on your mind @(User.Identity.Name)?</h3>
             <form method="post" style="display:flex; gap:8px; align-items:flex-start;">
+                @Html.AntiForgeryToken()
                 <input type="text" asp-for="Text" />
                 <input type="submit" value="Share" />
             </form>
@@ -72,13 +73,13 @@
         @if (Model.ShowPrevious)
         {
             <li class="">
-                <a href="/@Model.Author?page=@(Model.page - 1)">Previous</a>
+                <a href="/@Model.Author?page=@(Model.PageNum - 1)">Previous</a>
             </li>
         }
         @if (Model.ShowNext)
         {
             <li class="">
-                <a href="/@Model.Author?page=@(Model.page + 1)">Next</a>
+                <a href="/@Model.Author?page=@(Model.PageNum + 1)">Next</a>
             </li>
         }
     </ul>
@@ -86,7 +87,7 @@
         <ul class="pagination">
             @for (var i = 1; i <= Model.TotalPages; i++)
             {
-                <li class="page-item @(i == Model.page ? "active" : "")">
+                <li class="page-item @(i == Model.PageNum ? "active" : "")">
                     <a href="/@Model.Author?page=@i">@i</a>
                 </li>
             }

--- a/test/Chirp.Razor.Tests/PublicPageTests.cs
+++ b/test/Chirp.Razor.Tests/PublicPageTests.cs
@@ -142,7 +142,7 @@ public class PublicPageTests
         var repo = new CheepRepository(ctx);
         var authorRepo = new AuthorRepository(ctx);
         var svc = new CheepService(repo);
-        var page = new UserTimelineModel(svc, authorRepo) { page = 1 };
+        var page = new UserTimelineModel(svc, authorRepo) { PageNum = 1 };
         
         page.PageContext = new PageContext
         {


### PR DESCRIPTION
  the 'page' property name was conflicting with asp.net core razor pages' internal routing which resulted in the ModelState validation to fail with 'The value '/UserTimeline' is not valid for page.'.

  in order to fix it, i renamed page property to PageNum to avoid having naming conflicts. Also changed from [BindProperty] to [FromQuery] to bind only from query string, and then i added antiforgery token to the form.
