### PR TITLE
Fix Like button redirect on UserTimeline page

### DIFF
--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -54,9 +54,9 @@
                         @cheep.Message
                         <small>&mdash; @cheep.Timestamp, @cheep.Likes  likes</small>
                     </p>
-                    <form method="post">
+                    <form method="post" asp-page-handler="Like">
                         <input type="hidden" name="id" value="@cheep.CheepId"/>
-                        <button type="submit" formaction="/?handler=Like">Like</button>
+                        <button type="submit">Like</button>
                     </form>
                 </li>
             }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -132,4 +132,10 @@ public class UserTimelineModel : PageModel
         FollowingList = await _service.GetFollowing(authorName);
         return RedirectToPage("/UserTimeline", new { author = author, page = PageNum });
     }
+
+    public IActionResult OnPostLike(string author, int id)
+    {
+        _service.LikeCheep(id);
+        return RedirectToPage("/UserTimeline", new { author = author, page = PageNum });
+    }
 }


### PR DESCRIPTION
   the like button was hardcoded to submit to the public page handler, which resulted in users being redirected away from the usertimeline. Fixed it by adding an OnPostLike handler to UserTimelineModel and updated the form to use asp-page-handler.
